### PR TITLE
add line numbers

### DIFF
--- a/machine.php
+++ b/machine.php
@@ -39,7 +39,7 @@ function instructions() {
   var lines = $('#source').val().split("\n");
   var out = '';
   for (var i = 0; i < lines.length; i++)
-    out += '<span id="inst_' + i + '" class="inst ' + (i%2==1?'odd':'even') + '">' + lines[i] + '&nbsp;</span>';
+    out += '<span id="inst_' + i + '" class="inst ' + (i%2==1?'odd':'even') + '">' + i + ': '+ lines[i] + '&nbsp;</span>';
   $('#instructions').html(out);
 }
 


### PR DESCRIPTION
I found it easier to see the line numbers when writing the call function, instead of clicking on each of the output lines to determine 'k' number of lines to skip. 
